### PR TITLE
fix: derive pipeline result from step data instead of OTel COMPLETE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,7 +207,7 @@ GET /repositories/{accountUUID}/{repoUUID}
 ```
 The `account.uuid` is used as the workspace identifier (Bitbucket accepts UUIDs in place of slugs). The resolved `full_name` is then used for all subsequent channel and thread lookups.
 
-**Result values:** OTel `pipeline.state.result.name` uses different values than the REST API. The mapping is: `COMPLETE` → ✅, `FAILED` → ❌, `ERROR` → 🔴, `STOPPED` → ⏹. These differ from `repo:commit_status_*` which uses `SUCCESSFUL`/`FAILED`/`INPROGRESS`.
+**Result values:** Bitbucket OTel spans always deliver `pipeline.state.result.name = "COMPLETE"` for all terminal pipeline runs regardless of step outcomes — `FAILED`, `ERROR`, and `STOPPED` are also possible but not observed for step-level failures. The displayed result is therefore derived from the fetched step data (priority: `FAILED` > `ERROR` > all-`STOPPED`/`NOT_RUN` → `STOPPED` > fallback to OTel value). When step data is unavailable the OTel value is used directly. The REST API (used by the `*Builds:*` field) uses `SUCCESSFUL`/`FAILED`/`INPROGRESS`, which differ from OTel values. The `repo:commit_status_*` family also uses REST API values.
 
 **Run number:** The `pipeline_run.run_number` OTel attribute is delivered as a `stringValue` (not `intValue`) and is parsed via `strconv.Atoi`.
 
@@ -238,7 +238,7 @@ Both formats are followed by indented per-step lines when step data is available
 ```
 Trigger labels: `PUSH` → `automatic trigger`, `MANUAL` → `manual trigger`, `SCHEDULE` → `scheduled trigger`, anything else → lowercased + ` trigger`.
 
-Result text: `COMPLETE` → `Passed`, `FAILED` → `Failed`, `ERROR` → `Error`, `STOPPED` → `Stopped`.
+Result text: `COMPLETE`/`SUCCESSFUL` → `Passed`, `FAILED` → `Failed`, `ERROR` → `Error`, `STOPPED` → `Stopped`. The effective result shown is derived from step data when available (see **Result values** above) — not read directly from the OTel span.
 
 **Step breakdown:** After the debounce delay, the handler calls `GET /repositories/{workspace}/{repo}/pipelines/{pipeline.uuid}/steps/` to fetch step details. Note: the steps API requires `pipeline.uuid` (the build UUID, from OTel attribute `pipeline.uuid`), not `pipeline_run.uuid`. Each step is rendered on its own line below the header. Step result symbols: `✓` SUCCESSFUL, `✗` FAILED, `✗` ERROR, `–` STOPPED, `–` NOT_RUN. Failed and errored steps are hyperlinked to the Bitbucket UI; other steps show a plain name.
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -1048,8 +1048,8 @@ func TestHandler_Pipeline_LinkedToPRExistingThread(t *testing.T) {
 		t.Errorf("expected thread_ts=9999.0000, got %v", calls[0].Body["thread_ts"])
 	}
 	text, _ := calls[0].Body["text"].(string)
-	if !strings.Contains(text, "✅") {
-		t.Errorf("expected reply to contain ✅, got %q", text)
+	if !strings.Contains(text, "⚙️") {
+		t.Errorf("expected reply to contain pipeline emoji ⚙️, got %q", text)
 	}
 	// chat.update refreshes the opening message
 	if calls[1].Path != "/chat.update" {

--- a/internal/format/reply.go
+++ b/internal/format/reply.go
@@ -182,11 +182,49 @@ func commitStatusEmoji(state string) string {
 	}
 }
 
+// effectiveResult derives the overall pipeline result from step data when available.
+// Bitbucket OTel delivers "COMPLETE" for all terminal pipeline runs regardless of step
+// outcomes, so step data is required to distinguish passing from failing runs.
+// Priority: FAILED > ERROR > STOPPED (all steps) > fall back to otelResult.
+func effectiveResult(otelResult string, steps []event.PipelineStep) string {
+	if len(steps) == 0 {
+		return otelResult
+	}
+	hasFailed := false
+	hasError := false
+	allStoppedOrNotRun := true
+	for _, s := range steps {
+		switch s.Result {
+		case stateFailed:
+			hasFailed = true
+			allStoppedOrNotRun = false
+		case stateError:
+			hasError = true
+			allStoppedOrNotRun = false
+		case stateStopped, "NOT_RUN":
+			// counts as stopped / not run
+		default: // SUCCESSFUL and anything else
+			allStoppedOrNotRun = false
+		}
+	}
+	switch {
+	case hasFailed:
+		return stateFailed
+	case hasError:
+		return stateError
+	case allStoppedOrNotRun:
+		return stateStopped
+	default:
+		return otelResult
+	}
+}
+
 func formatPipelineRun(ev *event.PipelineRunEvent, resolve UserResolver, linked bool) string {
 	run := ev.PipelineRun
 
-	overallEmoji := pipelineResultEmoji(run.Result)
-	overallText := pipelineResultText(run.Result)
+	result := effectiveResult(run.Result, ev.Steps)
+	overallEmoji := pipelineResultEmoji(result)
+	overallText := pipelineResultText(result)
 	resultPart := overallEmoji
 	if overallText != "" {
 		resultPart = overallEmoji + " " + overallText

--- a/internal/format/reply_test.go
+++ b/internal/format/reply_test.go
@@ -292,7 +292,7 @@ func TestReply_PipelineStopped(t *testing.T) {
 }
 
 func TestReply_PipelineComplete(t *testing.T) {
-	// OTel result "COMPLETE" maps to ✅ Passed.
+	// OTel result "COMPLETE" with no steps falls back to ✅ Passed.
 	ev := &event.Event{
 		Key: event.KeyPipelineSpanCreated,
 		Pipeline: &event.PipelineRunEvent{
@@ -309,6 +309,130 @@ func TestReply_PipelineComplete(t *testing.T) {
 	}
 	assertContains(t, text, "✅")
 	assertContains(t, text, "Passed")
+}
+
+func TestReply_PipelineCompleteWithFailedStep(t *testing.T) {
+	// OTel delivers COMPLETE even when steps failed; the step data overrides to ❌ Failed.
+	ev := &event.Event{
+		Key: event.KeyPipelineSpanCreated,
+		Pipeline: &event.PipelineRunEvent{
+			PipelineRun: event.PipelineRun{
+				Result:  "COMPLETE",
+				RefName: "main",
+				URL:     "https://example.com/pipeline",
+			},
+			Steps: []event.PipelineStep{
+				{Name: "Build", Result: "SUCCESSFUL"},
+				{Name: "Test", Result: "FAILED", URL: "https://example.com/step/2"},
+				{Name: "Deploy", Result: "NOT_RUN"},
+			},
+		},
+	}
+	text, err := format.Reply(ev, defaultResolver(), format.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertContains(t, text, "❌")
+	assertContains(t, text, "Failed")
+	assertNotContains(t, text, "✅ Passed")
+}
+
+func TestReply_PipelineCompleteWithErrorStep(t *testing.T) {
+	// OTel delivers COMPLETE; a step with ERROR overrides to 🔴 Error.
+	ev := &event.Event{
+		Key: event.KeyPipelineSpanCreated,
+		Pipeline: &event.PipelineRunEvent{
+			PipelineRun: event.PipelineRun{
+				Result:  "COMPLETE",
+				RefName: "main",
+				URL:     "https://example.com/pipeline",
+			},
+			Steps: []event.PipelineStep{
+				{Name: "Build", Result: "ERROR", URL: "https://example.com/step/1"},
+			},
+		},
+	}
+	text, err := format.Reply(ev, defaultResolver(), format.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertContains(t, text, "🔴")
+	assertContains(t, text, "Error")
+	assertNotContains(t, text, "✅ Passed")
+}
+
+func TestReply_PipelineCompleteAllStoppedSteps(t *testing.T) {
+	// OTel delivers COMPLETE; all steps STOPPED overrides to ⏹ Stopped.
+	ev := &event.Event{
+		Key: event.KeyPipelineSpanCreated,
+		Pipeline: &event.PipelineRunEvent{
+			PipelineRun: event.PipelineRun{
+				Result:  "COMPLETE",
+				RefName: "main",
+				URL:     "https://example.com/pipeline",
+			},
+			Steps: []event.PipelineStep{
+				{Name: "Build", Result: "STOPPED"},
+				{Name: "Test", Result: "NOT_RUN"},
+			},
+		},
+	}
+	text, err := format.Reply(ev, defaultResolver(), format.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertContains(t, text, "⏹")
+	assertContains(t, text, "Stopped")
+	assertNotContains(t, text, "✅ Passed")
+}
+
+func TestReply_PipelineCompleteAllSuccessfulSteps(t *testing.T) {
+	// OTel delivers COMPLETE; all steps SUCCESSFUL → ✅ Passed.
+	ev := &event.Event{
+		Key: event.KeyPipelineSpanCreated,
+		Pipeline: &event.PipelineRunEvent{
+			PipelineRun: event.PipelineRun{
+				Result:  "COMPLETE",
+				RefName: "main",
+				URL:     "https://example.com/pipeline",
+			},
+			Steps: []event.PipelineStep{
+				{Name: "Build", Result: "SUCCESSFUL"},
+				{Name: "Test", Result: "SUCCESSFUL"},
+			},
+		},
+	}
+	text, err := format.Reply(ev, defaultResolver(), format.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertContains(t, text, "✅")
+	assertContains(t, text, "Passed")
+}
+
+func TestReply_PipelineFailedPriorityOverError(t *testing.T) {
+	// When both FAILED and ERROR steps exist, FAILED takes priority.
+	ev := &event.Event{
+		Key: event.KeyPipelineSpanCreated,
+		Pipeline: &event.PipelineRunEvent{
+			PipelineRun: event.PipelineRun{
+				Result:  "COMPLETE",
+				RefName: "main",
+				URL:     "https://example.com/pipeline",
+			},
+			Steps: []event.PipelineStep{
+				{Name: "Build", Result: "ERROR", URL: "https://example.com/step/1"},
+				{Name: "Test", Result: "FAILED", URL: "https://example.com/step/2"},
+			},
+		},
+	}
+	text, err := format.Reply(ev, defaultResolver(), format.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertContains(t, text, "❌")
+	assertContains(t, text, "Failed")
+	assertNotContains(t, text, "🔴")
 }
 
 func TestReply_PipelineLinkedToPR_OmitsRepoAndBranch(t *testing.T) {


### PR DESCRIPTION
## Summary
Bitbucket OTel spans always deliver `pipeline.state.result.name = "COMPLETE"` for all terminal pipeline runs regardless of step outcomes. This caused the thread reply to show ✅ Passed even when pipeline steps failed, contradicting the `*Builds:*` field in the opening message (which reads from the REST API and was correct).

## Related issue
Closes #30

## Changes
- Add `effectiveResult` helper in `internal/format/reply.go` that inspects fetched step data to derive the true pipeline outcome: `FAILED` steps → ❌ Failed, `ERROR` steps → 🔴 Error, all `STOPPED`/`NOT_RUN` steps → ⏹ Stopped, otherwise fall back to the OTel value (COMPLETE/SUCCESSFUL → ✅ Passed). Priority: FAILED > ERROR > STOPPED > fallback.
- Update `formatPipelineRun` to use `effectiveResult` instead of reading `run.Result` directly — step data is already available after the debounce fetch.
- Update `TestHandler_Pipeline_LinkedToPRExistingThread` assertion from `✅` to `⚙️`: the test's purpose is to verify threading (reply + chat.update), not the specific result emoji; the old `✅` assertion was testing the pre-fix wrong behavior.
- Update CLAUDE.md pipeline result documentation to reflect that `COMPLETE` is always the OTel value and that the displayed result is derived from step data.

## Adapter interface changes
N/A

## Test coverage
- [x] Unit tests added / updated
  - `TestReply_PipelineComplete` comment updated (no steps → COMPLETE fallback → ✅ Passed)
  - `TestReply_PipelineCompleteWithFailedStep` — COMPLETE + FAILED step → ❌ Failed
  - `TestReply_PipelineCompleteWithErrorStep` — COMPLETE + ERROR step → 🔴 Error
  - `TestReply_PipelineCompleteAllStoppedSteps` — COMPLETE + all STOPPED/NOT_RUN steps → ⏹ Stopped
  - `TestReply_PipelineCompleteAllSuccessfulSteps` — COMPLETE + all SUCCESSFUL steps → ✅ Passed
  - `TestReply_PipelineFailedPriorityOverError` — FAILED + ERROR steps → FAILED takes priority
- [x] Fixtures in `testdata/webhooks/` added / updated if new event payloads are involved — N/A, existing fixtures cover the scenarios
- [x] `testdata/webhooks/FIXTURES.md` updated if new fixture design decisions were made — N/A

## Checklist
- [x] `CLAUDE.md` updated if architecture or interfaces changed
- [x] No concrete adapter implementations added to the core library